### PR TITLE
Precise pool bounds

### DIFF
--- a/src/core/ngx_palloc.c
+++ b/src/core/ngx_palloc.c
@@ -22,6 +22,9 @@ ngx_create_pool(size_t size, ngx_log_t *log)
 
     if (size < sizeof(ngx_pool_t))
         size = sizeof(ngx_pool_t);
+#ifdef __CHERI_PURE_CAPABILITY__
+    size = __builtin_cheri_round_representable_length(size);
+#endif
 
     p = ngx_memalign(NGX_POOL_ALIGNMENT, size, log);
     if (p == NULL) {
@@ -170,7 +173,9 @@ ngx_palloc_small(ngx_pool_t *pool, size_t size, ngx_uint_t align)
             p->d.last = m + size;
 
 #ifdef __CHERI_PURE_CAPABILITY__
-            m = cheri_setbounds(m, size);
+            // This is safe so long as NGX_MAX_ALLOC_FROM_POOL is
+            // representable.  By default it's 4095 so safe.
+            m = cheri_setboundsexact(m, size);
 #endif
             return m;
         }
@@ -216,7 +221,7 @@ ngx_palloc_block(ngx_pool_t *pool, size_t size)
     p->d.next = new;
 
 #ifdef __CHERI_PURE_CAPABILITY__
-    m = cheri_setbounds(m, size);
+    m = cheri_setboundsexact(m, size);
 #endif
     return m;
 }

--- a/src/os/unix/ngx_alloc.c
+++ b/src/os/unix/ngx_alloc.c
@@ -69,6 +69,9 @@ ngx_memalign(size_t alignment, size_t size, ngx_log_t *log)
 }
 
 #elif (NGX_HAVE_MEMALIGN)
+#ifdef __CHERI_PURE_CAPABILITY__
+#error should be using posix_memalign
+#endif
 
 void *
 ngx_memalign(size_t alignment, size_t size, ngx_log_t *log)


### PR DESCRIPTION
In practice little seems to be required.  We round new pools up a representable sensible size (rather than letting `malloc` do it and ignoring the extra space), but small allocations are always `<= 4095` and should be representable. I've added an assertion that this is true. Large allocations are straight from `malloc` so nothing required there. nginx starts with this, but I've done no real testing.