### PR TITLE
script: rederive capability correctly when array is expanded

### DIFF
--- a/src/http/ngx_http_script.c
+++ b/src/http/ngx_http_script.c
@@ -797,7 +797,7 @@ ngx_http_script_add_code(ngx_array_t *codes, size_t size, void *code)
     if (code) {
         if (elts != codes->elts) {
             p = code;
-            *p += (u_char *) codes->elts - elts;
+            *p = (u_char *) codes->elts + (*p - elts);
         }
     }
 


### PR DESCRIPTION
We should rederive the capability from the reallocated array. It is similar to another PR #3. The bug is discovered when producing the PoC for CVE-2026-42945.